### PR TITLE
Included the StartDate and EndDate arguments in sample

### DIFF
--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -104,9 +104,9 @@ $rand = [System.Security.Cryptography.RandomNumberGenerator]::Create()
 $rand.GetBytes($bytes)
 $rand.Dispose()
 $newClientSecret = [System.Convert]::ToBase64String($bytes)
-New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Sign -Value $newClientSecret
-New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Verify -Value $newClientSecret
-New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Password -Usage Verify -Value $newClientSecret
+New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Sign -Value $newClientSecret -StartDate (Get-Date) -EndDate (Get-Date).AddYears(1)
+New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Verify -Value $newClientSecret -StartDate (Get-Date) -EndDate (Get-Date).AddYears(1)
+New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Password -Usage Verify -Value $newClientSecret -StartDate (Get-Date) -EndDate (Get-Date).AddYears(1)
 $newClientSecret
 ```
 


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        |  yes
| New article?        | no
| Related issues?     | N/A

#### What's in this Pull Request?

Included the -StartDate and -EndDate arguments in New-MsolServicePrincipalCredential PowerShell sample as these are mandatory, so a direct copy/paste doesn't work. It also nicely will show how to extend to last 3 years, which is what most customers prefer as I've noticed.